### PR TITLE
Add admin role check for retrieving case files

### DIFF
--- a/app/(app)/cases/view/[id]/page.tsx
+++ b/app/(app)/cases/view/[id]/page.tsx
@@ -20,9 +20,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useQuery } from "@tanstack/react-query";
-import { getCaseFilesById } from "@/lib/actions/case-file";
+import { getAdminCaseFilesById, getCaseFilesById } from "@/lib/actions/case-file";
+import { ROLES } from "@/types/auth";
+import { useAppSelector } from "@/hooks/redux";
 
 export default function SingleCasePage({ params }: { params: { id: string } }) {
+  const { data: user } = useAppSelector((state) => state.profile);
+
   const tabs: { id: any; label: string }[] = [
     { id: "overview", label: "Case Overview" },
     { id: "documents", label: "Documents" },
@@ -36,7 +40,19 @@ export default function SingleCasePage({ params }: { params: { id: string } }) {
   const { data, isLoading } = useQuery({
     queryKey: ["get_single_case_by_id"],
     queryFn: async () => {
-      return await getCaseFilesById(params.id);
+      if (
+        [
+          ROLES.DIRECTOR_MAGISTRATES,
+          ROLES.ASSIGNING_MAGISTRATES,
+          ROLES.PRESIDING_MAGISTRATES,
+          ROLES.CHIEF_JUDGE,
+          ROLES.CENTRAL_REGISTRY,
+        ].includes(user?.role as ROLES)
+      ) {
+        return await getAdminCaseFilesById(params.id);
+      } else {
+        return await getCaseFilesById(params.id);
+      }
     },
     enabled: !!params.id,
   });

--- a/lib/_services/case-file.ts
+++ b/lib/_services/case-file.ts
@@ -115,6 +115,11 @@ const CaseFileService = {
     console.log("case filter by id response", response.data);
     return response.data;
   },
+  async getAdminCaseFilesbyId(id: string): Promise<any> {
+    const response = await axiosInstance.get<any>(`admin/CaseFile/${id}`);
+    console.log("case filter by id response", response.data);
+    return response.data;
+  },
   async deleteCaseFiles(id: string): Promise<any> {
     const response = await axiosInstance.delete<string>(`casefile/${id}`);
     console.log("case filter response", response.data);

--- a/lib/actions/case-file.ts
+++ b/lib/actions/case-file.ts
@@ -45,6 +45,15 @@ export async function getCaseFilesById(id: string) {
     return handleApiError(error);
   }
 }
+export async function getAdminCaseFilesById(id: string) {
+  try {
+    const data = await CaseFileService.getAdminCaseFilesbyId(id);
+    return { ...data, success: true };
+  } catch (err: unknown) {
+    const error = err as ErrorResponse;
+    return handleApiError(error);
+  }
+}
 export async function deleteCase(id: string) {
   try {
     const data = await CaseFileService.deleteCaseFiles(id);


### PR DESCRIPTION
This commit adds an admin role check to the function responsible for retrieving case files in the SingleCasePage component. If the user has an admin role, the function will call the getAdminCaseFilesById method; otherwise, it will call the getCaseFilesById method. This change ensures that different case files are retrieved based on the user's role.